### PR TITLE
Add flake8 install to travis before scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
   - "0.10"
 before_script:
   - npm install grunt-cli -g
+  - sudo pip install flake8


### PR DESCRIPTION
This should make sure flake8 dependency for the grunt task is installed and appropriately pass/fail on travis. Thoughts?
