### PR TITLE
Use react to generate foosball rules from data/rules.json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@ env:
   browser: true
   node: true
   es6: true
+  jquery: true
 extends:
   - eslint:recommended
   - plugin:react/recommended
@@ -13,6 +14,7 @@ parserOptions:
 plugins:
   - react
 rules:
+  no-console: 0
   indent:
     - 2
     - 4

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var port = process.env.OPENSHIFT_NODEJS_PORT || process.env.PORT || 8080;
 var ip = process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1';
 
 app.use(express.static(__dirname + '/public'));
+app.use(express.static(__dirname + '/data'));
 
 app.listen(port, ip);
 

--- a/public/foosball_rules.html
+++ b/public/foosball_rules.html
@@ -8,92 +8,21 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
-<script src="//code.jquery.com/ui/1.11.4/jquery-ui.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
 <script type='text/babel' src="js/header.js"></script>
-<script>
-    $(function() {
-        $("#accordion").accordion();
-    });
-</script>
+<script type='text/babel' src="js/rules.js"></script>
+
+<style>
+    .panel-heading {
+        cursor: pointer;
+    }
+</style>
 </head>
 <body>
     <div id="header"></div>
-
-    <div id="accordion">
-        <h3> Winning conditions</h3>
-        <div>
-            <ul>
-                <li>The first team to reach eight points wins, so long as the other team does not have seven points when they do so.</li>
-                <li>If a team reaches eight points while the other has seven then the game continues until one team has <b>two</b> more points than the other team. Once this occurs the leading team wins.</li>
-            </ul>
-        </div>
-        <h3> Throw-in policy</h3>
-        <div>
-            <ul>
-                <li> Instead of throwing the ball in from the side of the arena, the ball is placed at the mids of one of the teams.</li>
-                <li> Every game starts with rock-paper-scissors. The winner of the rps game gets possession of the ball first, i.e. the ball is placed at their mids first.</li>
-                <li> On subsequent throw-ins, the ball is placed at the mids of the team who lost the point.</li>
-                <li> Goals scored on first touch do not count.</li>
-                <li> The ball must be placed at the middle player.</li>
-                <li> Once the ball has been placed, and the hand has been taken off the ball, the ball may not be moved. If the ball is 'dead', the dead ball rule is consulted. </li>
-            </ul>
-        </div>
-        <h3> Knocked out ball</h3>
-        <div>
-            <ul>
-                <li> If the ball is knocked out, it is placed at the mids of the team who lost the last point.</li>
-            </ul>
-        </div>
-        <h3> Dead ball</h3>
-        <div>
-            <ul>
-                <li> Both teams must agree that a ball is dead before any player touches the ball.</li>
-                <li> If the ball is dead and near the center, it is placed at the mids of the team who lost the last point.</li>
-                <li> If the ball is ahead of a teams forwards, it is placed at the nearest corner.</li>
-            </ul>
-        </div>
-        <h3> Beers</h3>
-        <div>
-            <ul>
-                <li> Beering must be declared and agreed upon by both team members at the beginning of a game. </li>
-                <li> If a team loses without scoring a single goal, that team must buy the other team a beer. </li>
-                <ul>
-                    <li> 1v1 case: loser buys winner a beer </li>
-                    <li> 2v2 case: forward loser buys forward winner a beer, defender loser buys defender winner a beer</li>
-                    <li> 2v1 case: If the single player team loses, they must buy a beer for each other player. If the duo team loses, they must each buy the opposing team a beer.</li>
-                </ul>
-            </ul>
-        </div>
-        <h3>Moving of the table</h3>
-        <div>
-            <ul>
-                <li> No moving of the table.</li>
-            </ul>
-        </div>
-        <h3>Spinning</h3>
-        <div>
-            <ul>
-                <li>Spins are not allowed.</li>
-            </ul>
-            <ul>
-                <li>What's a spin?</li>
-                <ul>
-                    <li>If it looks like a spin.</li>
-                    <li>If it smells like a spin.</li>
-                    <li>If it tastes like a spin.</li>
-                    <li>It's a spin.</li>
-                </ul>
-            </ul>
-        </div>
-        <h3>Time outs</h3>
-        <div>
-            <ul>
-                <li>Each team is allowed two time outs per game during which the players may leave the table. Such time outs shall not exceed 30 seconds. If the ball is in play, time out may be called only by the team in possession of the ball, and then only if the ball is completely stopped. If the ball is not in play, either team may call time out.</li>
-            </ul>
-        </div>
-    </div>
-</body>
+    <div id="rules"></div>
 <script>
     d3.select("#foosball-rules-header").style("opacity", 0).transition().duration(1000).style("opacity", 1);
 </script>

--- a/public/js/rules.js
+++ b/public/js/rules.js
@@ -1,0 +1,84 @@
+var Rule = React.createClass({
+    propTypes: {
+        name: React.PropTypes.string.isRequired,
+        contents: React.PropTypes.object.isRequired,
+        id: React.PropTypes.string.isRequired
+    },
+    render: function() {
+        var contentNodes = this.props.contents.map(function(c) {
+            return (
+                // Get raw data so any html formatting in the model isn't lost.
+                // eslint-disable-next-line react/no-danger
+                <li dangerouslySetInnerHTML={{__html:c.toString()}} />
+            );
+        });
+        return (
+            <div className="panel panel-default">
+                <div className="panel-heading" data-toggle="collapse" data-parent="#accordion" href={'#' + this.props.id}>
+                    <h4 className="panel-title">
+                        <a> {this.props.name} </a>
+                    </h4>
+                </div>
+                <div id={this.props.id} className="panel-collapse collapse">
+                    <div className="panel-body">
+                        <ul>
+                            {contentNodes}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+});
+
+var RuleList = React.createClass({
+    propTypes: {
+        data: React.PropTypes.object.isRequired
+    },
+    render: function() {
+        var ruleNodes = this.props.data.map(function(r, i) {
+            return (
+                <Rule name={r.name} contents={r.contents} id={i} />
+            );
+        });
+        return (
+            <div className="panel-group" id="accordion">
+                {ruleNodes}
+            </div>
+        );
+    }
+});
+
+var RuleContainer = React.createClass({
+    propTypes: {
+        url: React.PropTypes.string.isRequired
+    },
+    getInitialState: function() {
+        return {data: []};
+    },
+    componentDidMount: function() {
+        $.ajax({
+            url: this.props.url,
+            dataType: 'json',
+            cache: false,
+            success: function(data) {
+                this.setState({data: data});
+            }.bind(this),
+            error: function(xhr, status, err) {
+                console.error(this.props.url, status, err.toString());
+            }.bind(this)
+        });
+    },
+    render: function() {
+        return (
+            <div>
+                <RuleList data={this.state.data} />
+            </div>
+        );
+    }
+});
+
+ReactDOM.render(
+    <RuleContainer url="rules.json" />,
+    document.getElementById('rules')
+);


### PR DESCRIPTION
Hello,

This is a work in progress (somewhat messy) fix for #11, I'm making an early PR to get some review, but also to get some help regarding issues that I'll outline below.

~~**Issue 1)** Using jquery accordion UI on rules doesn't work.~~

~~You can put jquery in one of the state changes as is done right now to get rules.json in RuleBox  (line 45 in /public/js/rules.js). However due to the nature of JSX I had to add extra div's to separate stuff (i.e. html returned in jsx has to be wrapped in divs). This separation doesn't allow the script to work since each `<h3>` element is also wrapped in a div.~~

~~This could be solved easily if accordion allows using something like `<div className="rule">` instead of `<h3>` elements but I don't believe you can. Please let me know if someone can think of a workaround for this (perhaps a better alternative to accordion or simply restructuring my code).~~ 

**Issue 2)** Possible problem with current api to use GET request on /rules.json to obtain rules.

As you may have noticed I added rules.json to be served by express. I don't know if we want to make this public like this, and if we do should we make a more formalized api for this?

Thanks!
